### PR TITLE
docs: revamp README and README-zh_CN with routes, env, and dev scripts

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -1,4 +1,4 @@
-# Serverless Cloud Notepad 云笔记
+# cloudflare-notepad 云笔记
 
 [![cloudflare workers](https://badgen.net/badge/a/Cloudflare%20Workers/orange?icon=https%3A%2F%2Fworkers.cloudflare.com%2Fresources%2Flogo%2Flogo.svg&label=)](https://workers.cloudflare.com/)
 ![example workflow](https://github.com/veegn/serverless-cloud-notepad/actions/workflows/deploy.yml/badge.svg)
@@ -7,31 +7,64 @@
 
 [English](./README.md) | 简体中文
 
-一个轻量的无服务云笔记项目，适合记录文本，并在多设备之间或与朋友共享。
+一个轻量的无服务云笔记项目，支持快速记录、格式化和安全分享。
 
 项目基于 Cloudflare Workers、Workers KV 和 GitHub Actions，易于私有化部署。
 
-## 功能
+`static/js/app.js` 会在本地启动、测试和部署前自动构建，前端源码位于 `frontend/`。
 
-- 现代化界面，支持浅色和深色主题。
-- 支持 Markdown、JSON、YAML 实时预览。
-- 输入时自动保存到 Cloudflare KV。
-- 支持为笔记设置密码，并同时保护查看和编辑。
-- 支持基于认证的 Raw 原文读取。
-- 无需传统后端和数据库运维。
+## 功能亮点
 
-## 使用方式
+- 首页（`/`）提供欢迎视图与首页笔记预览。
+- 支持通过 `/.create` 一键创建随机路径笔记。
+- 编辑与查看页面均基于 Cloudflare KV 自动保存。
+- 支持四种内容模式：纯文本、Markdown、JSON、YAML。
+- Markdown 支持分栏实时预览，并可在编辑 / 分栏 / 预览布局间切换。
+- 内置格式化能力（按钮 + 快捷键）用于结构化内容。
+- 支持浅色 / 深色主题切换，并记住用户偏好。
+- 支持笔记密码保护（查看与编辑）。
+- 支持私有笔记（`share: false`）与鉴权后的 Raw 原文读取。
+- 支持为首页笔记（`.index`）启用独立管理员编辑密码。
 
-- 访问 `/` 可打开存储在 `.index` 中的首页笔记。
-- 访问 `/.create` 会生成一个随机路径，并直接进入编辑页。
-- 访问 `/:path/edit` 可编辑笔记或设置密码。
-- 访问 `/:path` 可查看笔记；受保护笔记需要先完成认证。
+## 路由说明
 
-在线示例：[https://juu.qzz.io](https://juu.qzz.io)
+| 路由 | 说明 |
+| --- | --- |
+| `/` | 首页笔记（`.index`）仪表盘视图 |
+| `/.index/edit` | 编辑首页笔记（可配置管理员密码保护） |
+| `/.create` | 生成 5 位随机路径并跳转到编辑页 |
+| `/:path` | 查看指定笔记 |
+| `/:path/edit` | 编辑指定笔记 |
+| `/:path/raw` | 获取笔记原文（受保护/私有笔记需先鉴权） |
+| `/:path/edit/auth` | 密码鉴权接口 |
+| `/:path/edit/pw` | 设置或移除笔记密码 |
+| `/:path/edit/setting` | 更新笔记设置（当前支持 `mode`） |
 
-## 兼容性
+## 环境变量
 
-- 支持现代桌面、平板和移动端浏览器。
+在 Worker 或 GitHub Actions 中建议配置：
+
+```bash
+SCN_SALT           # 用于兼容旧密码逻辑的盐
+SCN_SECRET         # JWT 签名密钥
+SCN_INDEX_PASSWD   # 可选：保护 /.index/edit 的管理员密码
+```
+
+## 本地开发
+
+```bash
+npm install
+npm start
+```
+
+常用脚本：
+
+- `npm run build:frontend:dev`：构建开发版前端包。
+- `npm run build:frontend:prod`：构建生产版前端包。
+- `npm run lint`：检查前后端 TypeScript 代码规范。
+- `npm run typecheck`：执行 Worker 与前端的类型检查。
+- `npm run test:e2e`：运行 Playwright 端到端测试。
+- `npm run check`：串行执行 lint + typecheck + e2e。
 
 ## 部署
 
@@ -47,7 +80,7 @@ SCN_SECRET
 3. 视情况更新 `wrangler.toml` 中的 KV 绑定配置。
 4. 在 Actions 页面运行 `Deploy cloud-notepad` 工作流。
 
-本地部署也可以直接执行：
+本地部署也可以执行：
 
 ```bash
 npm install
@@ -57,4 +90,4 @@ npm run deploy
 ## 致谢
 
 - 灵感来自 [s0urcelab/serverless-cloud-notepad](https://github.com/s0urcelab/serverless-cloud-notepad)
-- 使用了 [Cloudflare Workers](https://workers.cloudflare.com/)、[itty-router](https://github.com/kwhitley/itty-router)、[marked](https://github.com/markedjs/marked)、[DOMPurify](https://github.com/cure53/dompurify)、[dayjs](https://github.com/iamkun/dayjs) 和 [js-yaml](https://github.com/nodeca/js-yaml)
+- 使用了 [Cloudflare Workers](https://workers.cloudflare.com/)、[itty-router](https://github.com/kwhitley/itty-router)、[CodeMirror](https://codemirror.net/)、[marked](https://github.com/markedjs/marked)、[DOMPurify](https://github.com/cure53/dompurify)、[dayjs](https://github.com/iamkun/dayjs) 和 [js-yaml](https://github.com/nodeca/js-yaml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serverless Cloud Notepad
+# cloudflare-notepad
 
 [![cloudflare workers](https://badgen.net/badge/a/Cloudflare%20Workers/orange?icon=https%3A%2F%2Fworkers.cloudflare.com%2Fresources%2Flogo%2Flogo.svg&label=)](https://workers.cloudflare.com/)
 ![example workflow](https://github.com/veegn/serverless-cloud-notepad/actions/workflows/deploy.yml/badge.svg)
@@ -7,33 +7,64 @@
 
 English | [简体中文](./README-zh_CN.md)
 
-A lightweight serverless notepad for recording text and sharing it across devices or with friends.
+A lightweight serverless notepad for quick writing, formatting, and secure sharing.
 
 Built with Cloudflare Workers, Workers KV, and GitHub Actions. Easy to self-host.
 
 The frontend bundle under `static/js/app.js` is generated during local start, tests, and deploy. Source files live in `frontend/`.
 
-## Features
+## Highlights
 
-- Modern UI with light and dark theme support.
-- Real-time preview for Markdown, JSON, and YAML.
-- Auto-save to Cloudflare KV while typing.
-- Password-protected notes for both viewing and editing.
-- Raw text endpoint for authenticated reads.
-- Zero traditional backend or database management.
+- Home dashboard (`/`) with a welcome view and home-note preview.
+- One-click random note creation via `/.create`.
+- Editing and viewing routes with automatic save to Cloudflare KV.
+- Multi-mode writing: plain text, Markdown, JSON, and YAML.
+- Markdown split-view editor with live preview and layout switching (Edit / Split / Preview).
+- Format tools for structured content (button + keyboard shortcut).
+- Light/dark theme toggle with browser preference + local persistence.
+- Password protection for note reading and editing.
+- Optional private-note mode (`share: false`) and authenticated raw endpoint.
+- Optional admin password to protect editing for the home note (`.index`).
 
-## Usage
+## Route overview
 
-- Visit `/` to open the homepage note stored at `.index`.
-- Visit `/.create` to generate a random note path and jump into edit mode.
-- Visit `/:path/edit` to edit a note or set its password.
-- Visit `/:path` to view a note. Protected notes require authentication before viewing.
+| Route | Description |
+| --- | --- |
+| `/` | Home note (`.index`) dashboard view |
+| `/.index/edit` | Edit home note (can be protected by admin password) |
+| `/.create` | Generate random 5-char path and redirect to edit page |
+| `/:path` | View a note |
+| `/:path/edit` | Edit a note |
+| `/:path/raw` | Get note raw text (requires auth for protected/private note) |
+| `/:path/edit/auth` | Password authentication endpoint |
+| `/:path/edit/pw` | Set or remove note password |
+| `/:path/edit/setting` | Update note settings (currently supports `mode`) |
 
-Try it: [https://juu.qzz.io](https://juu.qzz.io)
+## Environment variables
 
-## Compatibility
+Set these in your Worker/GitHub Actions environment:
 
-- Modern browsers on desktop, tablet, and mobile.
+```bash
+SCN_SALT           # salt used for legacy password compatibility
+SCN_SECRET         # JWT signing secret
+SCN_INDEX_PASSWD   # optional: protect /.index/edit with admin password
+```
+
+## Local development
+
+```bash
+npm install
+npm start
+```
+
+Useful scripts:
+
+- `npm run build:frontend:dev`: development frontend bundle.
+- `npm run build:frontend:prod`: production frontend bundle.
+- `npm run lint`: lint backend + frontend TypeScript.
+- `npm run typecheck`: TypeScript checks for worker and frontend configs.
+- `npm run test:e2e`: Playwright E2E tests.
+- `npm run check`: lint + typecheck + e2e.
 
 ## Deployment
 
@@ -56,9 +87,7 @@ npm install
 npm run deploy
 ```
 
-If you clone the repo for development, run `npm start`, `npm run test:e2e`, or `npm run build:frontend:prod` before expecting the generated frontend bundle to exist locally.
-
 ## Credits
 
 - Inspired by [s0urcelab/serverless-cloud-notepad](https://github.com/s0urcelab/serverless-cloud-notepad)
-- Built with [Cloudflare Workers](https://workers.cloudflare.com/), [itty-router](https://github.com/kwhitley/itty-router), [marked](https://github.com/markedjs/marked), [DOMPurify](https://github.com/cure53/dompurify), [dayjs](https://github.com/iamkun/dayjs), and [js-yaml](https://github.com/nodeca/js-yaml)
+- Built with [Cloudflare Workers](https://workers.cloudflare.com/), [itty-router](https://github.com/kwhitley/itty-router), [CodeMirror](https://codemirror.net/), [marked](https://github.com/markedjs/marked), [DOMPurify](https://github.com/cure53/dompurify), [dayjs](https://github.com/iamkun/dayjs), and [js-yaml](https://github.com/nodeca/js-yaml)


### PR DESCRIPTION
### Motivation
- Clarify project name and purpose and provide a more complete, user-friendly introduction to features and routes. 
- Surface required environment variables and local development commands to make self-hosting and testing easier. 
- Align Chinese and English documentation and update referenced frontend tooling and libraries. 

### Description
- Renamed top-level project heading to `cloudflare-notepad` and tightened the project description in both `README.md` and `README-zh_CN.md`. 
- Reworked feature list into a concise "Highlights" section and added a detailed route overview table covering `/.create`, `/.index/edit`, `/:path`, `/:path/raw`, and related endpoints. 
- Added an "Environment variables" section documenting `SCN_SALT`, `SCN_SECRET`, and `SCN_INDEX_PASSWD`, and a "Local development" section with `npm install`, `npm start` and common scripts such as `npm run build:frontend:dev`, `npm run build:frontend:prod`, `npm run lint`, `npm run typecheck`, `npm run test:e2e`, and `npm run check`. 
- Updated credits/dependencies to include `CodeMirror` and adjusted other wording and badges; synchronized the Chinese README to mirror the English changes. 

### Testing
- This is a documentation-only change and does not modify runtime code paths, so no automated tests were necessary. 
- Existing CI workflows remain unchanged and will run normally on future code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b196d38e008332aa1af34deb38f454)